### PR TITLE
Remove 'used'-flag as such

### DIFF
--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -1,6 +1,7 @@
 #include "Block.hpp"
 
 #include "Declarations.hpp"
+#include "FreeBlock.hpp"
 
 /*
  * Takes 16 bytes in memory
@@ -20,7 +21,6 @@ Block::Block(TypeDescriptor* typeDescriptor) {
 #endif
 
 	this->typeDescriptor = typeDescriptor;
-	this->used = true;
 }
 
 Block::~Block() = default;
@@ -30,12 +30,12 @@ Block::~Block() = default;
  * If the block is not marked as "used", then a nullptr is returned
  */
 void* Block::getDataPart() {
-	if (!this->used) {
+	if (isFreeBlock()) {
 		return nullptr;
 	}
 
 	// "this + sizeof(Block)" is the effective getDataPart for the block
-	return this + sizeof (Block);
+	return this + sizeof(Block);
 }
 
 int Block::totalSize() const {
@@ -52,14 +52,22 @@ int Block::dataSize() const {
 
 std::string Block::ToString() const {
 	std::string str = "Block { ";
-	if (this->used) {
-		str += "used: true, ";
-	} else {
-		str += "used: false, ";
-	}
+	str += "used: true, ";
 	str += "totalSize: " + std::to_string(totalSize()) + ", ";
 	str += "headerSize: " + std::to_string(headerSize()) + ", ";
 	str += "dataSize: " + std::to_string(dataSize());
 	str += "}";
 	return str;
+}
+
+
+/**
+ * Takes a block and checks if it is a FreeBlock. <br>
+ * The function checks if the TypeDescriptor points to the body of the block
+ * @param blk The body to check
+ * @return True if the block is a FreeBlock, otherwise false
+ */
+bool Block::isFreeBlock() {
+	FreeBlock* fb = (FreeBlock*) this;
+	return (void*) fb->typeDescriptor == fb->dataPosition();
 }

--- a/src/Block.hpp
+++ b/src/Block.hpp
@@ -8,7 +8,6 @@ class Block {
 public:
 	// Heap
 	TypeDescriptor* typeDescriptor;
-	bool used;
 
 	// GC
 	/*
@@ -24,6 +23,7 @@ public:
 
 	// Additional member function declarations, if needed
 	std::string ToString() const;
+	bool isFreeBlock();
 
 	/**
 	* Returns the getDataPart pointer of this block.

--- a/src/FreeBlock.cpp
+++ b/src/FreeBlock.cpp
@@ -15,7 +15,6 @@ FreeBlock::FreeBlock(int requestedSize) : Block(nullptr) {// Explicitly null her
 	}
 #endif
 
-	this->used = false;
 	// typeDescriptor is a pointer to the data part of the free block
 	this->typeDescriptor = (TypeDescriptor*) dataPosition();
 	// Size of the data part of the whole free block

--- a/src/FreeBlock.hpp
+++ b/src/FreeBlock.hpp
@@ -3,8 +3,6 @@
 
 #include "Block.hpp"
 
-
-
 /**
  * "A special "Block" that is used to mark free memory.
  * The "typeDescriptor" points to the data part of the block.
@@ -22,9 +20,9 @@ public:
 	static long getMinFreeBlockSize();
 	void setNextFreePointer(void* nextFree);
 	void setObjSize(int size);
+	void* dataPosition() const;
 
 private:
-	void* dataPosition() const;
 	int getObjSize() const;
 };
 

--- a/src/Heap.cpp
+++ b/src/Heap.cpp
@@ -149,7 +149,7 @@ std::string Heap::ToString() {
 	Block* bCur = (Block*) heap_buffer;
 	while (bCur != nullptr && traversedSize < HEAP_SIZE) {
 		int curBlkSize;
-		if (bCur->used) {
+		if (bCur->isFreeBlock()) {
 			// Normal Block
 			str += "" + bCur->ToString() + postfix;
 			postfix = ", ";
@@ -203,7 +203,7 @@ void Heap::dump() const {
 	Block* bCur = (Block*) heap_buffer;
 	while (bCur != nullptr && traversedSize < HEAP_SIZE) {
 		int curBlkSize;
-		if (bCur->used) {
+		if (bCur->isFreeBlock()) {
 			// Normal Block
 			curBlkSize = bCur->totalSize();
 			char* data = (char*) bCur->getDataPart();


### PR DESCRIPTION
Replaced `used`-flag by a method that checks if the TypeDescriptor of a Block points to the data area of said Block. Using this approach reduces header size to 8 bytes instead of 16 bytes